### PR TITLE
Fix image not getting measured when only height or width is zero

### DIFF
--- a/library/src/main/java/com/santalu/aspectratioimageview/AspectRatioImageView.java
+++ b/library/src/main/java/com/santalu/aspectratioimageview/AspectRatioImageView.java
@@ -49,21 +49,21 @@ public class AspectRatioImageView extends AppCompatImageView {
         int height = getMeasuredHeight();
         int width = getMeasuredWidth();
 
-        if (width == 0 || height == 0) {
-            return;
-        }
-
         Log.i(TAG, String.format("width %s height %s", width, height));
 
         switch (mAspect) {
             case Aspect.AUTO:
                 if (height > width) {
+                    if (width == 0) return;
+
                     mAspect = Aspect.WIDTH;
                     mAspectRatio = Math.round((double) height / width);
                     setMeasuredDimension((int) (height * mAspectRatio), height);
                 } else {
+                    if (height == 0) return;
+
                     mAspect = Aspect.HEIGHT;
-                    mAspectRatio = Math.round((double) height / width);
+                    mAspectRatio = Math.round((double) width / height);
                     setMeasuredDimension(width, (int) (width * mAspectRatio));
                 }
                 break;


### PR DESCRIPTION
It is a valid use case to only set either the height or the width to a value higher than 0 and let the other one get calculated by the `AspectRatioImageView`.
With the current version (`1.0.1`), the measurement is aborted in that case and the image does not show up.
This PR fixes that.